### PR TITLE
allow disabling of cache to optionally query for latest results

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -10,8 +10,8 @@ exports.install = module.exports.install = function(mongoose, options) {
 		exec: mongoose.Query.prototype.exec
 	};
 
-	mongoose.Query.prototype.cache = function() {
-		this.__cached = true;
+	mongoose.Query.prototype.cache = function(enabled) {
+		this.__cached = enabled === false ? false : true;
 		return this;
 	};
 


### PR DESCRIPTION
Frequently, you want to be able to force a full update on a normally-cached query. This PR allows you to select to cache or not with a boolean argument like:

``` js
function query(fresh, done) {
  this.find()
    .sort('-createdAt')
    .limit(n || 50)
    .cache(!fresh)
    .exec(done);
}
```
