### PR TITLE
Get the iru cache object

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,8 @@ db.User.find({ ... }).cache().exec(function() { ... })
 ```
 
 For more talky output add ```debug: true``` to the cacheOpts.
+
+For getting the lru cache object in order to have access to its API
+```javascript
+mongoose.getCache()
+```

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -83,6 +83,9 @@ exports.install = module.exports.install = function(mongoose, options, Aggregate
 	mongoose.Query.prototype.exec = function(arg1, arg2) {
 		return exec.call(this, 'exec', arguments);
 	};
+	mongoose.getCache = function() {
+		return cache;
+	};
 	if (typeof Aggregate !== 'undefined') {
 		Aggregate.prototype.exec = function(arg1, arg2) {
 			return exec.call(this, 'execAggregate', arguments);


### PR DESCRIPTION
The project limits the developer by making the cache object inaccessible. I needed to use its API in a project, so I made a small change. Now the cache object can be used

```javascript
mongoose.getCache()
```