### PR TITLE
Add per-query maxAge and maxAge randomization

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -9,15 +9,18 @@ exports.install = module.exports.install = function(mongoose, options, Aggregate
 		execFind: mongoose.Query.prototype.execFind,
 		exec: mongoose.Query.prototype.exec
 	};
-	mongoose.Query.prototype.cache = function() {
+	mongoose.Query.prototype.cache = function(maxAge) {
+		// maxAge is optional; otherwise it will use global LRU cache options maxAge.
 		this.__cached = true;
+		this.__maxAge = maxAge;
 		return this;
 	};
 
 	if (typeof Aggregate !== 'undefined') {
 		orig.execAggregate = Aggregate.prototype.exec;
-		Aggregate.prototype.cache = function() {
+		Aggregate.prototype.cache = function(maxAge) {
 			this.__cached = true;
+			this.__maxAge = maxAge;
 			return this;
 		};
 	}
@@ -28,7 +31,8 @@ exports.install = module.exports.install = function(mongoose, options, Aggregate
 		}
 		var key = genKey(this),
 			obj = cache.get(key),
-			i;
+			i,
+			maxAge = this.__maxAge;
 
 		if (obj) {
 			log('cache hit: ', key);
@@ -43,8 +47,11 @@ exports.install = module.exports.install = function(mongoose, options, Aggregate
 
 		function cacheSet(err, obj) {
 			if (!err) {
-				log('save to cache: ', key);
-				cache.set(key, obj);
+				if (maxAge) {
+					var maxAgeRandomized = (0.75 + 0.5 * Math.random()) * maxAge;
+				}
+				log('save to cache: ', key, maxAgeRandomized);
+				cache.set(key, obj, maxAgeRandomized);
 			}
 			this.apply(this, arguments);
 		}


### PR DESCRIPTION
node-lru-cache lets you set a specific `maxAge` on each key that overrides the default `maxAge` you might have set in the global options, which comes in handy–this passes that along. Additionally, it randomizes the specific `maxAge` a bit to help avoid the case where multiple instances all started at the same time all have their caches expire at the same time.

Example:

``` javascript
// Cache this query for between 7.5 and 12.5 minutes.
db.User.find({ ... }).cache(10 * 60 * 1000).exec(function() { ... })

// Default behavior (unchanged): cache according to global maxAge option.
db.User.find({ ... }).cache().exec(function() { ... })
```
